### PR TITLE
Add "Start REPL And Attach" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,10 @@
                 "title": "Alive: Compile File"
             },
             {
+                "command": "alive.startReplAndAttach",
+                "title": "Alive: Start REPL And Attach"
+            },
+            {
                 "command": "alive.attachRepl",
                 "title": "Alive: Attach To REPL"
             },
@@ -158,6 +162,9 @@
         ],
         "menus": {
             "commandPalette": [
+                {
+                    "command": "alive.startReplAndAttach"
+                },
                 {
                     "command": "alive.attachRepl"
                 },
@@ -344,6 +351,11 @@
         "configuration": {
             "title": "Common Lisp",
             "properties": {
+                "alive.swank.startCommand": {
+                    "type": "array",
+                    "default": ["/usr/bin/ros", "run", "--eval", "(ql:quickload :swank) (let ((swank::*loopback-interface* \"0.0.0.0\")) (swank:create-server :port 4005 :style :spawn :dont-close t))"],
+                    "description": "Lisp code that will be evaluated to start a swank server"
+                },
                 "alive.format.indentWidth": {
                     "type": "number",
                     "default": 2,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,6 +87,7 @@ export const activate = async (ctx: vscode.ExtensionContext) => {
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.sendToRepl', () => cmds.sendToRepl(state)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.inlineEval', () => cmds.inlineEval(state)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.clearInlineResults', () => cmds.clearInlineResults(state)))
+    ctx.subscriptions.push(vscode.commands.registerCommand('alive.startReplAndAttach', () => cmds.startReplAndAttach(state, ctx)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.attachRepl', () => cmds.attachRepl(state, ctx)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.detachRepl', () => cmds.detachRepl(state)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.replHistory', () => cmds.replHistory(state)))

--- a/src/vscode/commands/Repl.ts
+++ b/src/vscode/commands/Repl.ts
@@ -76,24 +76,20 @@ export async function startReplAndAttach(state: ExtensionState, ctx: vscode.Exte
             attachRepl(state, ctx)
         }
     }
-    const spawn = () => {
-        child = childProcess.spawn(cmd[0], cmd.slice(1))
-        child.stdout.setEncoding('utf8');
-        child.stdout.on('data', data => outputAndAttach(data));
 
-        child.stderr.setEncoding('utf8');
-        child.stderr.on('data', data => outputAndAttach(data));
-    }
-    if (child) {
-        child.kill()
-        vscode.window.showInformationMessage("Waiting for Swank to die...")
-        // For some reason 'exit' event wasn't getting called every time so I'm using timeout.
-        setTimeout(() => {
-            spawn()
-        }, 3000)
-    } else {
-        spawn()
-    }
+    child?.kill()
+    child = null
+
+    child = childProcess.spawn(cmd[0], cmd.slice(1))
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', data => outputAndAttach(data));
+
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', data => outputAndAttach(data));
+
+    child.on('error', (err) => {
+        vscode.window.showErrorMessage(`Couldn't spawn Swank server: ${err.message}`)
+    })
 }
 
 export async function attachRepl(state: ExtensionState, ctx: vscode.ExtensionContext) {


### PR DESCRIPTION
Hey, Is this project is open to contributions?
I was getting annoyed that I need to start swank server manually every time so I've added this new command called "Start REPL And Attach" which does it automatically. By default it uses roswell but it's all customizable by `alive.swank.startCommand` parameter. Let me know what do you think.