### PR TITLE
Added Jack-In option for REPL startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,10 @@
                 "title": "Alive: Compile File"
             },
             {
+                "command": "alive.startReplAndAttach",
+                "title": "Alive: Start REPL And Attach"
+            },
+            {
                 "command": "alive.attachRepl",
                 "title": "Alive: Attach To REPL"
             },
@@ -167,6 +171,9 @@
                 },
                 {
                     "command": "alive.detachRepl"
+                },
+                {
+                    "command": "alive.startReplAndAttach"
                 },
                 {
                     "command": "alive.replHistory",
@@ -395,6 +402,19 @@
                 "alive.remoteWorkspace": {
                     "type": "string",
                     "description": "Path on the REPL server to the workspace"
+                },
+                "alive.swank.startupCommand": {
+                    "type": "array",
+                    "default": [
+                        "sbcl",
+                        "--eval",
+                        "(ql:quickload :swank)",
+                        "--eval",
+                        "(asdf:load-system :swank)",
+                        "--eval",
+                        "(swank:create-server)"
+                    ],
+                    "description": "Command to start up a Swank server to which your REPL can connect."
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,6 +90,7 @@ export const activate = async (ctx: vscode.ExtensionContext) => {
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.sendToRepl', () => cmds.sendToRepl(state)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.inlineEval', () => cmds.inlineEval(state)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.clearInlineResults', () => cmds.clearInlineResults(state)))
+    ctx.subscriptions.push(vscode.commands.registerCommand('alive.startReplAndAttach', () => cmds.startReplAndAttach(state, ctx)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.attachRepl', () => cmds.attachRepl(state, ctx)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.detachRepl', () => cmds.detachRepl(state)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.replHistory', () => cmds.replHistory(state, false)))

--- a/src/vscode/repl/FileView.ts
+++ b/src/vscode/repl/FileView.ts
@@ -1,6 +1,7 @@
 import { EOL } from 'os'
 import * as vscode from 'vscode'
 import { createFolder, getTempFolder, jumpToBottom, openFile, REPL_ID } from '../Utils'
+import { format } from 'util'
 import { View } from './View'
 
 export class FileView implements View {
@@ -38,7 +39,7 @@ export class FileView implements View {
 
             this.replDoc = await openFile(this.replFile)
         } catch (err) {
-            vscode.window.showErrorMessage(err)
+            vscode.window.showErrorMessage(format(err))
         }
     }
 


### PR DESCRIPTION
This commit adds the ability to start a REPL and automatically connect
to it.  The command to start the REPL is configurable.  The default
command assumes that sbcl is being used with quicklisp.  It also sets
the path of the REPL to the root of the project on startup.  This should
make it easier to use the starting path for environment names in CLPM
and to make things less confusing in general.  This setup should be
compatible with starting the repl in CLPM and Roswell without
forcing the user into using either.