### PR TITLE
Added automatic REPL config and startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ This extension contributes the following settings:
 -   `alive.autoLoadOnSave`: If true, load files into the REPL when saved.
 -   `alive.remoteWorkspace`: Path to the workspace files on the REPL. Used when loading files.
 -   `alive.indentMacros`: Defaults to true. When connected to the REPL, indent any form with a &body parameter instead of aligning like a normal list.
+-   `alive.swank.startupCommand`: Allows configuration of the command used to start up SBCL with the REPL.  It defaults to an SBCL configuration that works with the Swank downloader.
+-   `alive.swank.checkForLatest`: This setting specifies whether VSCode should check for the latest version of Swank every time the REPL is started.  Defaults to false.
+-   `alive.swank.downloadUrl`: Specifies the url from which to download a Slime/Swank release.  Defaults to https://api.github.com/repos/slime/slime/releases.
 
 The indentMacros setting was added because, while correct to indent macros, it makes fomatting very slow on large files. Setting it to false turns that behavior off.
 
@@ -88,6 +91,10 @@ Note that the inline result feature uses a hover to display results, so those re
 ### Select S-Expression (Alt+Shift+Up)
 
 Selects the surrounding top level expression for the current cursor position.
+
+### Start REPL And Attach
+
+Downloads and installs a swank server, runs it in your image, and connects to it.
 
 ### Attach To REPL
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "alive",
-    "version": "0.1.10",
+    "version": "0.1.13",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -22,6 +22,14 @@
             "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
             "dev": true
         },
+        "axios": {
+            "version": "0.21.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "requires": {
+                "follow-redirects": "^1.14.0"
+            }
+        },
         "buffer-from": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -34,11 +42,21 @@
             "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true
         },
+        "follow-redirects": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
+            "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw=="
+        },
         "make-error": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
             "dev": true
+        },
+        "node-stream-zip": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
+            "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw=="
         },
         "source-map": {
             "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,10 @@
                 "title": "Alive: Compile File"
             },
             {
+                "command": "alive.startReplAndAttach",
+                "title": "Alive: Start REPL And Attach"
+            },
+            {
                 "command": "alive.attachRepl",
                 "title": "Alive: Attach To REPL"
             },
@@ -167,6 +171,9 @@
                 },
                 {
                     "command": "alive.detachRepl"
+                },
+                {
+                    "command": "alive.startReplAndAttach"
                 },
                 {
                     "command": "alive.replHistory",
@@ -395,6 +402,29 @@
                 "alive.remoteWorkspace": {
                     "type": "string",
                     "description": "Path on the REPL server to the workspace"
+                },
+                "alive.swank.downloadUrl": {
+                    "type": "string",
+                    "description": "Https url from which to download slime/swank release",
+                    "default": "https://api.github.com/repos/slime/slime/releases"
+                },
+                "alive.swank.checkForLatest": {
+                    "type": "boolean",
+                    "description": "Specifies whether VSCode should check for the latest version of slime/swank every time the REPL is started",
+                    "default": false
+                },
+                "alive.swank.startupCommand": {
+                    "type": "array",
+                    "default": [
+                        "sbcl",
+                        "--eval",
+                        "(require :asdf)",
+                        "--eval",
+                        "(asdf:load-system :swank)",
+                        "--eval",
+                        "(swank:create-server)"
+                    ],
+                    "description": "Command to start up a Swank server to which your REPL can connect."
                 }
             }
         }
@@ -404,5 +434,9 @@
         "@types/vscode": "^1.50.0",
         "ts-node": "^9.0.0",
         "typescript": "^4.0.3"
+    },
+    "dependencies": {
+        "axios": "^0.21.4",
+        "node-stream-zip": "^1.15.0"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ import {
     getFoldProvider,
     getHoverProvider,
     getRenameProvider,
-    getSemTokensProvider
+    getSemTokensProvider,
 } from './vscode/providers'
 import { ExtensionState } from './vscode/Types'
 import { COMMON_LISP_ID, hasValidLangId, REPL_ID, updatePkgMgr, useEditor } from './vscode/Utils'
@@ -81,6 +81,7 @@ export const activate = async (ctx: vscode.ExtensionContext) => {
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.sendToRepl', () => cmds.sendToRepl(state)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.inlineEval', () => cmds.inlineEval(state)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.clearInlineResults', () => cmds.clearInlineResults(state)))
+    ctx.subscriptions.push(vscode.commands.registerCommand('alive.startReplAndAttach', () => cmds.startReplAndAttach(state, ctx)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.attachRepl', () => cmds.attachRepl(state, ctx)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.detachRepl', () => cmds.detachRepl(state)))
     ctx.subscriptions.push(vscode.commands.registerCommand('alive.replHistory', () => cmds.replHistory(state, false)))

--- a/src/swank/SwankConn.ts
+++ b/src/swank/SwankConn.ts
@@ -125,7 +125,10 @@ export class SwankConn extends EventEmitter {
             this.conn?.on('error', (err) => {
                 connected ? this.connError(err) : reject(err)
             })
-
+            this.conn?.on('end', () => {
+                const err = new Error('ALIVEUNEXPECTEDDISCONNECT')
+                connected ? this.connError(err) : reject(err)
+            })
             this.conn?.on('close', () => this.connClosed())
             this.conn?.on('data', (data) => this.readData(data))
         })

--- a/src/vscode/Types.ts
+++ b/src/vscode/Types.ts
@@ -1,8 +1,22 @@
+import { ChildProcess } from 'child_process'
 import { PackageMgr } from './PackageMgr'
 import { Repl } from './repl'
 
 export interface ExtensionState {
+    child?: ChildProcess
     repl?: Repl
+    slimeBasePath?: string
     pkgMgr: PackageMgr
     hoverText: string
+}
+
+export interface SlimeVersion {
+    created_at: string
+    name: string
+    zipball_url: string
+}
+
+export interface InstalledSlimeInfo {
+    path: string
+    latest: SlimeVersion | undefined
 }

--- a/src/vscode/Utils.ts
+++ b/src/vscode/Utils.ts
@@ -241,7 +241,7 @@ export async function getTempFolder() {
     }
 
     if (baseFolder === undefined) {
-        throw new Error('No folder for REPL file')
+        throw new Error('No folder for REPL file, is file saved to disk?')
     }
 
     return vscode.Uri.joinPath(baseFolder, OUTPUT_DIR)
@@ -317,6 +317,10 @@ function getActiveDocFolder() {
     }
 
     const docPath = path.parse(activeDoc.uri.path)
+
+    if (docPath.dir === '') {
+        return undefined
+    }
 
     return vscode.Uri.file(docPath.dir)
 }

--- a/src/vscode/repl/FileView.ts
+++ b/src/vscode/repl/FileView.ts
@@ -1,6 +1,7 @@
 import { EOL } from 'os'
 import * as vscode from 'vscode'
 import { createFolder, getTempFolder, jumpToBottom, openFile, REPL_ID } from '../Utils'
+import { format } from 'util'
 import { View } from './View'
 
 export class FileView implements View {
@@ -38,7 +39,7 @@ export class FileView implements View {
 
             this.replDoc = await openFile(this.replFile)
         } catch (err) {
-            vscode.window.showErrorMessage(err)
+            vscode.window.showErrorMessage(format(err))
         }
     }
 


### PR DESCRIPTION
Added automatic REPL config and startup

This commit adds the ability to download Swank if it isn't already
downloaded, add it to the ASDF path, start Swank, and attach the REPL to
it.  The command to start the REPL is configurable.  The default command
uses SBCL, but it can be overridden in the config.  The mechanism for
adding Swank should work with all lisps that use ASDF 3.x.

It sets the path of the REPL to the root of the project on startup.
This should make it easier to use the starting path for environment
names in CLPM and to make things less confusing in general.  This setup
should be compatible with starting the repl in CLPM and Roswell without
forcing the user into using either.

Ultimately, this should make it so that VSCode users can get a REPL
via the editor instead of having to manually start it up first.

It adds two dependencies because I had a hell of a time with the limited
functionality of the built-in node HTTP libraries and zlib libraries.  I
apologize. I just couldn't do what I wanted to do without rewriting two
fairly hefty libs.