### PR TITLE
Fix #78

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "internalConsoleOptions": "openOnSessionStart",
-            "args": ["--extensionDevelopmentPath=${workspaceFolder}"]
+            "args": ["--disable-extensions", "--extensionDevelopmentPath=${workspaceFolder}"],
+            "preLaunchTask": "npm: compile"
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "alive",
     "displayName": "Alive",
     "description": "Average Lisp VSCode Environment",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "publisher": "rheller",
     "repository": {
         "url": "https://github.com/nobody-famous/alive"

--- a/src/vscode/commands/Repl.ts
+++ b/src/vscode/commands/Repl.ts
@@ -569,7 +569,7 @@ function getClSourceRegistryEnv(
 ): { [key: string]: string | undefined } {
     const updatedEnv = { ...processEnv }
     if (!processEnv.CL_SOURCE_REGISTRY) {
-        updatedEnv.CL_SOURCE_REGISTRY = slimePath
+        updatedEnv.CL_SOURCE_REGISTRY = slimePath + ":"
         return updatedEnv
     }
     if (processEnv.CL_SOURCE_REGISTRY.startsWith('(')) {

--- a/src/vscode/commands/Repl.ts
+++ b/src/vscode/commands/Repl.ts
@@ -569,7 +569,7 @@ function getClSourceRegistryEnv(
 ): { [key: string]: string | undefined } {
     const updatedEnv = { ...processEnv }
     if (!processEnv.CL_SOURCE_REGISTRY) {
-        updatedEnv.CL_SOURCE_REGISTRY = slimePath + ":"
+        updatedEnv.CL_SOURCE_REGISTRY = slimePath + path.delimiter
         return updatedEnv
     }
     if (processEnv.CL_SOURCE_REGISTRY.startsWith('(')) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
         "outDir": "out",
-        "sourceMap": false,
+        "sourceMap": true,
     },
     "include": [
         "src/**/*.ts",


### PR DESCRIPTION
A fix for Unix-like system. This should work for SBCL on Unix and Cygwin, but I believe this will not work for SBCL on windows.

On Windows, the path separator is ';', but I don't know a way to determine how SBCL is built. I suppose either the extension parses the shell version into S-expr version, or we let the user specify it (adding a configuration).

Also, given that I have good experience with Alive with ABCL, we might need to consider their support too.