### PR TITLE
Fix extension build/debug process

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,11 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "internalConsoleOptions": "openOnSessionStart",
-            "args": ["--disable-extensions", "--extensionDevelopmentPath=${workspaceFolder}"]
+            "args": [
+                // "--disable-extensions",
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "preLaunchTask": "${defaultBuildTask}"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,10 +11,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "internalConsoleOptions": "openOnSessionStart",
-            "args": [
-                // "--disable-extensions",
-                "--extensionDevelopmentPath=${workspaceFolder}"
-            ],
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
             "preLaunchTask": "${defaultBuildTask}"
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,7 +41,10 @@
             "problemMatcher": [
                 "$tsc"
             ],
-            "group": "build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
             "label": "npm: build",
             "detail": "tsc -p ./tsconfig.build.json"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "alive",
-    "version": "0.3.19",
+    "version": "0.3.21",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "alive",
-            "version": "0.3.19",
+            "version": "0.3.21",
             "dependencies": {
                 "axios": "^0.21.4",
                 "node-stream-zip": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -270,6 +270,18 @@
             }
         ],
         "menus": {
+            "editor/context": [
+                {
+                    "command": "alive.loadFile",
+                    "when": "editorLangId == lisp",
+                    "group": "z_commands"
+                },
+                {
+                    "command": "alive.compileFile",
+                    "when": "editorLangId == lisp",
+                    "group": "z_commands"
+                }
+            ],
             "view/title": [
                 {
                     "command": "alive.refreshPackages",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "alive",
     "displayName": "Alive",
     "description": "Average Lisp VSCode Environment",
-    "version": "0.3.20",
+    "version": "0.3.21",
     "publisher": "rheller",
     "repository": {
         "url": "https://github.com/nobody-famous/alive"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,17 @@ import { UI } from './vscode/UI'
 import { log, toLog } from './vscode/Log'
 import { getHoverProvider } from './vscode/providers/Hover'
 
+// Word separator characters for CommonLisp.
+// These determine how a double-click will extend over a symbol.
+// Instead of defining what is contained in a symbol,
+// VSCode defines what is NOT in a symbol (or whatever).
+//
+// Using current (2023-04-27) version of config item minus hyphen.
+// Could also get() the default setting at load time and remove the hyphen
+// but it seems like a good idea to take control of this configuration item
+// in order to be independent of any future changes to the default setting.
+const wordSeparators = "`|;:'\",()"
+
 export const activate = async (ctx: vscode.ExtensionContext) => {
     log(`Activating extension`)
 
@@ -23,6 +34,8 @@ export const activate = async (ctx: vscode.ExtensionContext) => {
     const aliveConfig = vscode.workspace.getConfiguration('alive')
     const editorConfig = vscode.workspace.getConfiguration('editor')
     await editorConfig.update('formatOnType', true, false, true)
+    const lispConfig = vscode.workspace.getConfiguration('', { languageId: COMMON_LISP_ID });
+    await lispConfig.update("editor.wordSeparators", wordSeparators, false, true)
 
     log(`Format On Type: ${editorConfig.get('formatOnType')}`)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,17 +13,6 @@ import { UI } from './vscode/UI'
 import { log, toLog } from './vscode/Log'
 import { getHoverProvider } from './vscode/providers/Hover'
 
-// Word separator characters for CommonLisp.
-// These determine how a double-click will extend over a symbol.
-// Instead of defining what is contained in a symbol,
-// VSCode defines what is NOT in a symbol (or whatever).
-//
-// Using current (2023-04-27) version of config item minus hyphen.
-// Could also get() the default setting at load time and remove the hyphen
-// but it seems like a good idea to take control of this configuration item
-// in order to be independent of any future changes to the default setting.
-const wordSeparators = "`~!@#$%^&*()=+[{]}\\|;:'\",.<>/?"
-
 export const activate = async (ctx: vscode.ExtensionContext) => {
     log(`Activating extension`)
 
@@ -34,8 +23,6 @@ export const activate = async (ctx: vscode.ExtensionContext) => {
     const aliveConfig = vscode.workspace.getConfiguration('alive')
     const editorConfig = vscode.workspace.getConfiguration('editor')
     await editorConfig.update('formatOnType', true, false, true)
-    const lispConfig = vscode.workspace.getConfiguration('', { languageId: COMMON_LISP_ID });
-    await lispConfig.update("editor.wordSeparators", "`~!@#$%^&*()=+[{]}\\|;:'\",.<>/?", false, true)
 
     log(`Format On Type: ${editorConfig.get('formatOnType')}`)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,17 @@ import { UI } from './vscode/UI'
 import { log, toLog } from './vscode/Log'
 import { getHoverProvider } from './vscode/providers/Hover'
 
+// Word separator characters for CommonLisp.
+// These determine how a double-click will extend over a symbol.
+// Instead of defining what is contained in a symbol,
+// VSCode defines what is NOT in a symbol (or whatever).
+//
+// Using current (2023-04-27) version of config item minus hyphen.
+// Could also get() the default setting at load time and remove the hyphen
+// but it seems like a good idea to take control of this configuration item
+// in order to be independent of any future changes to the default setting.
+const wordSeparators = "`~!@#$%^&*()=+[{]}\\|;:'\",.<>/?"
+
 export const activate = async (ctx: vscode.ExtensionContext) => {
     log(`Activating extension`)
 
@@ -23,6 +34,8 @@ export const activate = async (ctx: vscode.ExtensionContext) => {
     const aliveConfig = vscode.workspace.getConfiguration('alive')
     const editorConfig = vscode.workspace.getConfiguration('editor')
     await editorConfig.update('formatOnType', true, false, true)
+    const lispConfig = vscode.workspace.getConfiguration('', { languageId: COMMON_LISP_ID });
+    await lispConfig.update("editor.wordSeparators", "`~!@#$%^&*()=+[{]}\\|;:'\",.<>/?", false, true)
 
     log(`Format On Type: ${editorConfig.get('formatOnType')}`)
 

--- a/src/vscode/UI.ts
+++ b/src/vscode/UI.ts
@@ -102,8 +102,8 @@ export class UI extends EventEmitter {
                 const editor = await vscode.window.showTextDocument(doc, vscode.ViewColumn.One)
                 const pos = new vscode.Position(line, char)
                 const range = new vscode.Range(
-                    new vscode.Position(pos.line - 10, pos.character),
-                    new vscode.Position(pos.line + 10, pos.character)
+                    new vscode.Position(Math.max(0, pos.line - 10), pos.character),
+                    new vscode.Position(Math.max(0, pos.line + 10), pos.character)
                 )
 
                 editor.selection = new vscode.Selection(pos, pos)

--- a/src/vscode/views/DebugView.ts
+++ b/src/vscode/views/DebugView.ts
@@ -1,11 +1,8 @@
 import { EventEmitter } from 'events'
 import * as path from 'path'
 import * as vscode from 'vscode'
-import { isPosition } from '../Guards'
 import { DebugInfo, RestartInfo } from '../Types'
 import { strToHtml } from '../Utils'
-// import * as event from '../../swank/event'
-// import { Frame, FrameVariable } from '../../swank/Types'
 
 interface jsMessage {
     command: string
@@ -17,15 +14,11 @@ export class DebugView extends EventEmitter {
     title: string
     panel?: vscode.WebviewPanel
     info: DebugInfo
-    // event: event.Debug
-    // activate?: event.DebugActivate
     frameExpanded: { [index: number]: boolean | undefined } = {}
-    // frameLocals: { [index: number]: FrameVariable[] | undefined } = {}
     frameEval: { [index: number]: string | undefined } = {}
     frameInput: { [index: number]: string | undefined } = {}
     viewCol: vscode.ViewColumn
 
-    // constructor(ctx: vscode.ExtensionContext, title: string, viewCol: vscode.ViewColumn, event: event.Debug) {
     constructor(ctx: vscode.ExtensionContext, title: string, viewCol: vscode.ViewColumn, info: DebugInfo) {
         super()
 
@@ -33,7 +26,6 @@ export class DebugView extends EventEmitter {
         this.title = title
         this.viewCol = viewCol
         this.info = info
-        // this.event = event
     }
 
     run() {
@@ -87,11 +79,6 @@ export class DebugView extends EventEmitter {
         this.panel = undefined
     }
 
-    // setLocals(ndx: number, locals: FrameVariable[]) {
-    //     this.frameLocals[ndx] = locals
-    //     this.renderHtml()
-    // }
-
     jumpTo(msg: jsMessage) {
         const file = typeof msg.file === 'string' ? msg.file : undefined
         const line = typeof msg.line === 'number' ? msg.line : undefined
@@ -108,7 +95,6 @@ export class DebugView extends EventEmitter {
     }
 
     private inspectCondCommand() {
-        // this.emit('inspect-cond', this.event.threadID)
     }
 
     private frameRestartCommand(msg: jsMessage) {
@@ -152,17 +138,10 @@ export class DebugView extends EventEmitter {
 
         this.frameExpanded[num] = !this.frameExpanded[num]
 
-        // if (this.frameLocals[num] === undefined) {
-        //     this.emit('frame-locals', num)
-        // }
-
         this.renderHtml()
     }
 
     private restartCommand(msg: jsMessage) {
-        // const restart = this.event.restarts[num]
-        // this.emit('restart', num, restart)
-
         if (typeof msg.number === 'number') {
             this.emit('restart', msg.number)
         }
@@ -186,99 +165,6 @@ export class DebugView extends EventEmitter {
             </div>
         `
     }
-
-    private renderLocals(ndx: number) {
-        let str = `<div class="locals-title">Locals:</div>`
-
-        // const locals = this.frameLocals[ndx] ?? []
-
-        // for (const local of locals) {
-        //     str += `<div class="locals-var">${local.name} = ${local.value}</div>`
-        // }
-
-        return str
-    }
-
-    // private isRestartable(bt: Frame): boolean {
-    //     const opts = bt.opts ?? []
-
-    //     for (const opt of opts) {
-    //         if (opt.name.toUpperCase() === ':RESTARTABLE' && opt.value) {
-    //             return true
-    //         }
-    //     }
-
-    //     return false
-    // }
-
-    private renderRestartBtn(ndx: number) {
-        return `<button class="debug-btn restart-btn" onclick="frame_restart(${ndx})")>
-                    R
-                </button>`
-    }
-
-    private renderEvalInFrame(ndx: number) {
-        let str = ''
-
-        str += `<div class="eval-box">
-                    <div class="eval-row">
-                        <div class="eval-label">
-                            <button class="debug-btn eval-btn" onclick="frame_eval(${ndx})">
-                                Eval
-                            </button>
-                        </div>
-                        <div class="eval-input-box">
-                            <form onsubmit="frame_eval(${ndx})">
-                                <input id="eval-input-${ndx}" type="text" class="eval-input"
-                                    onchange="input_changed(${ndx})"
-                                    value="${this.frameInput[ndx] ?? ''}"
-                                >
-                            </form>
-                        </div>
-                    </div>
-                    <div class="eval-row">
-                        <div class="eval-label"></div>
-                        <div class="eval-result-box">
-                            <input type="text" readonly class="eval-result" value="${this.frameEval[ndx] ?? ''}">
-                        </div>
-                    </div>
-                </div>`
-
-        return str
-    }
-
-    private renderExpanded(ndx: number) {
-        if (!this.frameExpanded[ndx]) {
-            return ''
-        }
-
-        let str = `<div class="locals-box">
-                       ${this.renderLocals(ndx)}
-                       ${this.renderEvalInFrame(ndx)}
-                   </div>`
-
-        return str
-    }
-
-    // private renderBtTable(bt: Frame) {
-    //     let str = ''
-
-    //     str += `<table class="frame-table list-item">
-    //               <tbody>
-    //                 <tr>
-    //                     <td class="frame-btn-cell">${this.isRestartable(bt) ? this.renderRestartBtn(bt.num) : ''}</td>
-    //                     <td class="frame-num-cell">${bt.num}:</td>
-    //                     <td class="frame-data-cell">
-    //                         <div class="clickable" onclick="bt_locals(${bt.num})">
-    //                             ${bt.desc}
-    //                         </div>
-    //                         ${this.renderExpanded(bt.num)}
-    //                     </td>
-    //                 </tr>
-    //               </tbody>
-    //             </table>`
-    //     return str
-    // }
 
     private renderBtList() {
         let str = ''
@@ -316,10 +202,6 @@ export class DebugView extends EventEmitter {
             `
             ndx -= 1
         }
-
-        // for (const bt of this.event.frames) {
-        //     str += this.renderBtTable(bt)
-        // }
 
         return str
     }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,8 +1,8 @@
 {
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "out",
-        "sourceMap": false,
+        "outDir": "out/src",
+        "sourceMap": true,
     },
     "include": [
         "src/**/*.ts"


### PR DESCRIPTION
I kept getting the message:
    `Activating extension failed: Cannot find module /home/marc/work/lisp/alive/out/src/extension.js`
when I ran the debugger for the extension in VSCode.

The changes in this PR seem to fix things. I reconnected the `preLaunchTask` through the `build` task to `tsconfig.build.json`. The `build` task is set to default to avoid an annoying popup each time. The `tsconfig.build.json` file is then adjusted to put the files into the proper place. This brings that file into agreement with `tsconfig.test.json` and `tsconfig.watch.json`.

Two things that may need adjusting (and another PR):

1. I commented out disabling extensions because mine don't seem to affect things and I like them and
2. I turned on `sourceMap` for the build.

All of this is to make things work for me. I've spent more time thus far figuring out the VSCode extension development process than working on actual issues. Your greater level of experience with this stuff may enable you to point out how ignorant I am of the actual simple fix.  ;-)