### PR TITLE
Create language-specific word separator characters for CommonLisp

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ import { getHoverProvider } from './vscode/providers/Hover'
 // Could also get() the default setting at load time and remove the hyphen
 // but it seems like a good idea to take control of this configuration item
 // in order to be independent of any future changes to the default setting.
-const wordSeparators = "`|;:'\","
+const wordSeparators = "`|;:'\",()"
 
 export const activate = async (ctx: vscode.ExtensionContext) => {
     log(`Activating extension`)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ import { getHoverProvider } from './vscode/providers/Hover'
 // Could also get() the default setting at load time and remove the hyphen
 // but it seems like a good idea to take control of this configuration item
 // in order to be independent of any future changes to the default setting.
-const wordSeparators = "`~!@#$%^&*()=+[{]}\\|;:'\",.<>/?"
+const wordSeparators = "`|;:'\","
 
 export const activate = async (ctx: vscode.ExtensionContext) => {
     log(`Activating extension`)
@@ -35,7 +35,7 @@ export const activate = async (ctx: vscode.ExtensionContext) => {
     const editorConfig = vscode.workspace.getConfiguration('editor')
     await editorConfig.update('formatOnType', true, false, true)
     const lispConfig = vscode.workspace.getConfiguration('', { languageId: COMMON_LISP_ID });
-    await lispConfig.update("editor.wordSeparators", "`~!@#$%^&*()=+[{]}\\|;:'\",.<>/?", false, true)
+    await lispConfig.update("editor.wordSeparators", wordSeparators, false, true)
 
     log(`Format On Type: ${editorConfig.get('formatOnType')}`)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,17 @@ import { UI } from './vscode/UI'
 import { log, toLog } from './vscode/Log'
 import { getHoverProvider } from './vscode/providers/Hover'
 
+// Word separator characters for CommonLisp.
+// These determine how a double-click will extend over a symbol.
+// Instead of defining what is contained in a symbol,
+// VSCode defines what is NOT in a symbol (or whatever).
+//
+// Using current (2023-04-27) version of config item minus hyphen.
+// Could also get() the default setting at load time and remove the hyphen
+// but it seems like a good idea to take control of this configuration item
+// in order to be independent of any future changes to the default setting.
+const wordSeparators = "`~!@#$%^&*()=+[{]}\\|;:'\",.<>/?"
+
 export const activate = async (ctx: vscode.ExtensionContext) => {
     log(`Activating extension`)
 
@@ -23,6 +34,8 @@ export const activate = async (ctx: vscode.ExtensionContext) => {
     const aliveConfig = vscode.workspace.getConfiguration('alive')
     const editorConfig = vscode.workspace.getConfiguration('editor')
     await editorConfig.update('formatOnType', true, false, true)
+    const lispConfig = vscode.workspace.getConfiguration('', { languageId: COMMON_LISP_ID });
+    await lispConfig.update("editor.wordSeparators", "`~!@#$%^&*()=+[{]}\\|;:'\",.<>/?", false, true)
 
     log(`Format On Type: ${editorConfig.get('formatOnType')}`)
 


### PR DESCRIPTION
This enables a double-click on a symbol with hyphens in it to select the entire symbol. With a normal language this would break things in the case of one symbol being subtracted from another but in Lisp there are going to be spaces around the symbols so it should be fine.