### PR TITLE
Update dependencies to match latest @types/vscode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "alive",
-    "version": "0.3.19",
+    "version": "0.3.20",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "alive",
-            "version": "0.3.19",
+            "version": "0.3.20",
             "dependencies": {
                 "axios": "^0.21.4",
                 "node-stream-zip": "^1.15.0",
@@ -14,7 +14,7 @@
             },
             "devDependencies": {
                 "@types/node": "^14.14.2",
-                "@types/vscode": "^1.50.0",
+                "@types/vscode": "^1.77.0",
                 "ts-node": "^9.0.0",
                 "typescript": "^4.0.3"
             },
@@ -29,9 +29,9 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.68.1",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.1.tgz",
-            "integrity": "sha512-fXlaq13NT5yHh6yZ3c+UxXloTSk34mIvsNFYyQCeO5Po2BLFAwz7EZT4kQ43B64/aPcnAenyWy3QasrTofBOnQ==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
+            "integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
             "dev": true
         },
         "node_modules/arg": {
@@ -277,9 +277,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.68.1",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.1.tgz",
-            "integrity": "sha512-fXlaq13NT5yHh6yZ3c+UxXloTSk34mIvsNFYyQCeO5Po2BLFAwz7EZT4kQ43B64/aPcnAenyWy3QasrTofBOnQ==",
+            "version": "1.77.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
+            "integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
             "dev": true
         },
         "arg": {

--- a/package.json
+++ b/package.json
@@ -441,7 +441,7 @@
     },
     "devDependencies": {
         "@types/node": "^14.14.2",
-        "@types/vscode": "^1.50.0",
+        "@types/vscode": "^1.77.0",
         "ts-node": "^9.0.0",
         "typescript": "^4.0.3"
     },


### PR DESCRIPTION
When I started trying to run the current version of Alive in VScode development mode I was getting 178 errors during compiles until I blew away my `node_modules` directory and executed:
```
npm i @types/vscode
```
This resulted in changes to `package.json` and `package-lock.json` which are included in this PR.

Just changing the `devDependencies` in `package.json` didn't get rid of the errors or the necessity to run the above `npm` command. I don't know if this was due to some misconfiguration on my system (Ubuntu 22.04, npm 8.5.1) or if there is something that can be changed in the code to avoid the issue.

Regardless, I've been carrying around these changes from branch to branch without submitting them so I figured I'd write up a PR and toss it on the pile.
