### PR TITLE
Default Build Task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,9 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "internalConsoleOptions": "openOnSessionStart",
-            "args": ["--extensionDevelopmentPath=${workspaceFolder}"]
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+            "preLaunchTask": "${defaultBuildTask}"
         }
     ]
 }
+

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -31,7 +31,10 @@
             "problemMatcher": [
                 "$tsc"
             ],
-            "group": "build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
             "label": "npm: compile",
             "detail": "tsc -p ./"
         },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "out",
+        "outDir": "out/src",
         "sourceMap": false,
     },
     "include": [


### PR DESCRIPTION
I kept getting the message:
```
Activating extension failed: Cannot find module /home/marc/work/lisp/alive/out/src/extension.js
```
when I ran the debugger for the extension in VSCode.

The changes in this PR seem to fix things. I reconnected the `preLaunchTask` through the build task to `tsconfig.build.json`. The build task is set to default to avoid an annoying popup each time. The `tsconfig.build.json` file is then adjusted to put the files into the proper place. This brings that file into agreement with `tsconfig.test.json` and `tsconfig.watch.json`.

It has occurred to me that the contents of the `.vscode` directory are probably set by VSCode infrastructure and I'm manually editing something that is buried somewhere in the VSCode preferences. Sigh. I'll have to go looking for it.