### PR TITLE
Add more editor context menu items, order them, and split groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -272,14 +272,24 @@
         "menus": {
             "editor/context": [
                 {
+                    "command": "alive.inlineEval",
+                    "when": "editorLangId == lisp",
+                    "group": "x_commands@1"
+                },
+                {
+                    "command": "alive.sendToRepl",
+                    "when": "editorLangId == lisp",
+                    "group": "x_commands@2"
+                },
+                {
                     "command": "alive.loadFile",
                     "when": "editorLangId == lisp",
-                    "group": "z_commands"
+                    "group": "x_commands@3"
                 },
                 {
                     "command": "alive.compileFile",
                     "when": "editorLangId == lisp",
-                    "group": "z_commands"
+                    "group": "x_commands@4"
                 }
             ],
             "view/title": [


### PR DESCRIPTION
I realized that I wanted `alive.sendToRepl` on the editor context menu. I went through all of the commands and added `"alive.inlineEval` as well. None of the other commands seemed to be make sense.

The default ordering by command name looked wonky so I figured out how to order them in a way that made sense (to me) by appending `@#` after each group name. This gave me the proper order but the `Command Palette...` entry was stuffed in the middle.

Turns out there can be more groups than those documented in the VSCode extension development doc. The groups are organized alphabetically (hence `z_commands` for `Command Palette...`). So I moved the Alive commands into `x_commands` which looks pretty OK to me.

I further considered:

* splitting the new group into two so the sexpr commands and file commands would be in different groups and/or
* changing the `x_commands` group name to `x_Alive` or something like that.

I didn't do either of those things because I didn't want to get carried away (again), but ask for them if you like.