### PR TITLE
Fix log console

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -262,7 +262,7 @@ async function initThreadsTree(deps: ExtensionDeps) {
         const threads = await deps.lsp.listThreads()
         deps.ui.initThreadsTree(threads)
     } catch (err) {
-        console.log(`Failed to init threads tree: ${err}`)
+        log(`Failed to init threads tree: ${err}`)
     }
 }
 
@@ -271,7 +271,7 @@ async function initAsdfSystemsTree(deps: ExtensionDeps) {
         const systems = await deps.lsp.listAsdfSystems()
         deps.ui.initAsdfSystemsTree(systems)
     } catch (err) {
-        console.log(`Failed to init ASDF tree: ${err}`)
+        log(`Failed to init ASDF tree: ${err}`)
     }
 }
 
@@ -280,7 +280,7 @@ async function initPackagesTree(deps: ExtensionDeps) {
         const pkgs = await deps.lsp.listPackages()
         deps.ui.initPackagesTree(pkgs)
     } catch (err) {
-        console.log(`Failed to init packages tree: ${err}`)
+        log(`Failed to init packages tree: ${err}`)
     }
 }
 

--- a/src/vscode/backend/LSP.ts
+++ b/src/vscode/backend/LSP.ts
@@ -709,7 +709,7 @@ export class LSP extends EventEmitter {
 
             return { name, package: pkgName }
         } catch (err) {
-            console.log('Failed to get symbol', err)
+            log(`Failed to get symbol: ${err}`)
         }
     }
 
@@ -734,7 +734,7 @@ export class LSP extends EventEmitter {
 
             return strToMarkdown(respObj.value)
         } catch (err) {
-            console.log('HOVER FAILED', err)
+            log(`Hover failed: ${err}`)
         }
 
         return ''

--- a/src/vscode/backend/LSP.ts
+++ b/src/vscode/backend/LSP.ts
@@ -20,6 +20,7 @@ import {
     Thread,
 } from '../Types'
 import { COMMON_LISP_ID, hasValidLangId, parseToInt, strToMarkdown } from '../Utils'
+import { log, toLog } from '../Log'
 
 type RangeFunction = (editor: vscode.TextEditor) => Promise<vscode.Range | undefined>
 

--- a/src/vscode/commands/Repl.ts
+++ b/src/vscode/commands/Repl.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import { TextEncoder } from 'util'
 import { ExtensionDeps, ExtensionState, LispSymbol } from '../Types'
 import { COMMON_LISP_ID, createFolder, getFolderPath, strToMarkdown, updateDiagnostics, useEditor } from '../Utils'
+import { log, toLog } from '../Log'
 
 export function clearRepl(deps: ExtensionDeps) {
     deps.ui.clearRepl()
@@ -166,7 +167,7 @@ async function doMacroExpand(deps: ExtensionDeps, fn: (text: string, pkg: string
                 editor.edit((builder) => builder.replace(info.range, newText))
             }
         } catch (err) {
-            console.log(err)
+            log('Failed to expand macro: ${err}')
         }
     })
 }


### PR DESCRIPTION
Replace calls to `log.console()` which seem to fall on the floor with calls to the `log()` function defined in `VSCode/Log.ts`.