### PR TITLE
Ignore blank repl input

### DIFF
--- a/src/vscode/views/LispRepl.ts
+++ b/src/vscode/views/LispRepl.ts
@@ -97,7 +97,10 @@ export class LispRepl extends EventEmitter implements vscode.WebviewViewProvider
     }
 
     private doEval(text: string) {
-        this.emit('eval', this.package, text)
+        text = text.trim();
+        if (text.length != 0) {
+            this.emit('eval', this.package, text)
+        }
     }
 
     private getHtmlForView(): string {

--- a/src/vscode/views/LispRepl.ts
+++ b/src/vscode/views/LispRepl.ts
@@ -97,8 +97,7 @@ export class LispRepl extends EventEmitter implements vscode.WebviewViewProvider
     }
 
     private doEval(text: string) {
-        text = text.trim();
-        if (text.length != 0) {
+        if (text.trim().length != 0) {
             this.emit('eval', this.package, text)
         }
     }

--- a/src/vscode/views/LispRepl.ts
+++ b/src/vscode/views/LispRepl.ts
@@ -99,6 +99,8 @@ export class LispRepl extends EventEmitter implements vscode.WebviewViewProvider
     private doEval(text: string) {
         if (text.trim().length != 0) {
             this.emit('eval', this.package, text)
+        } else {
+            this.addText("")
         }
     }
 


### PR DESCRIPTION
I noticed that when I entered an empty string in the REPL input box at the bottom I got an error and a debug box on the right.  I found a place where I could fix this but I'm not certain this is the correct place to fix it. I can't imagine this breaking any legitimate usage.