### PR TITLE
Make a LICENSE clearer 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Average Lisp VSCode Environment",
     "version": "0.4.2",
     "publisher": "rheller",
+    "license": "Unlicense",
     "repository": {
         "url": "https://github.com/nobody-famous/alive"
     },


### PR DESCRIPTION
This pull request closes issue #183.

Thanks for the charm extension. I would like to propose to make the licence term clear (i.e. Public Domain) and to be OSI (Open Source Initiative) approved licences. 

The OpenVSX team offered me an automatic curation system from the Visual Studio Code marketplace.
I asked them to consider this extension as a curation target. https://github.com/open-vsx/publish-extensions/pull/735
They replied that the requirements are that the extension must be licensed under an OSI approved licence.

That's why I wrote the pull request that Public Domain should be Unlicense, which is very similar to Public Domain. I hope this is going well. 