### PR TITLE
Update README.md to add init documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ The following must be installed prior to useing the Alive extension. It is okay 
     - `(ql:quickload "cl-json")`
     - `(ql:quickload "flexi-streams")`
 
+
+    Make sure you run `(ql:add-to-init-file)` or add `(load "~/quicklisp/setup.lisp")` to the `~/.sbclrc` file to make sure these dependencies are loaded on startup.
+
     <details>
     <summary>An example SBCL and Quicklisp session (where `...` stands for a bunch of stuff printed to the console)</summary>
 


### PR DESCRIPTION
- For new users of lisp, it is unclear how quicklisp loads dependencies
    - I personally missed this the first time and I think others have too https://github.com/nobody-famous/alive/issues/197
- the quicklisp quickstart is fine but a bit verbose due to all the console output; it is easy for a new user who is skimming to miss how to auto load dependencies

Feel free to close or edit if you don't think this is reasonable. 