### PR TITLE
Added support for multi-value eval output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "alive",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "alive",
-            "version": "0.4.4",
+            "version": "0.4.5",
             "license": "Unlicense",
             "dependencies": {
                 "axios": "^1.6.0",

--- a/src/vscode/commands/Repl.ts
+++ b/src/vscode/commands/Repl.ts
@@ -32,13 +32,20 @@ export async function inlineEval(
             return
         }
 
-        const result = await lsp.eval(info.text, info.package)
+        const results = await lsp.eval(info.text, info.package)
 
-        if (result === undefined) {
+        if (results === undefined) {
             return
         }
 
-        state.hoverText = `=> ${strToMarkdown(result)}`
+        let evalOutput
+        if (Array.isArray(results)) {
+            evalOutput = results.join(', ')
+        } else {
+            evalOutput = results
+        }
+
+        state.hoverText = `=> ${strToMarkdown(evalOutput)}`
         await vscode.window.showTextDocument(editor.document, editor.viewColumn)
         vscode.commands.executeCommand('editor.action.showHover')
     })


### PR DESCRIPTION
Frontend changes to handle multiple values returned from `eval` and `inlineEval`. Changed REPL formatting output using `>` to distinguish between input and evaluation output.

Server pull request: https://github.com/nobody-famous/alive-lsp/pull/68

<img width="285" alt="Screenshot 2025-02-05 at 6 50 03 pm" src="https://github.com/user-attachments/assets/9e16d1f5-eabc-483b-b567-bb2880887634" />
<img width="246" alt="Screenshot 2025-02-05 at 6 50 16 pm" src="https://github.com/user-attachments/assets/4b0a9909-19b2-484e-939a-2b1c78107ac0" />
