### PR TITLE
Removed setting package on historyUp/Down event

### DIFF
--- a/src/vscode/UI.ts
+++ b/src/vscode/UI.ts
@@ -317,12 +317,11 @@ export class UI extends EventEmitter<UIEvents> {
             await this.requestPackage(this.replView)
         })
 
-        const updateReplInput = () => {
-            const item = this.historyTree.getCurrentItem()
+        const updateReplInputWithHistory = () => {
+            const historyItem = this.historyTree.getCurrentItem()
 
-            if (item !== undefined) {
-                this.replView.setPackage(item.pkgName)
-                this.replView.setInput(item.text)
+            if (historyItem !== undefined) {
+                this.replView.setInput(historyItem.text)
             } else {
                 this.replView.clearInput()
             }
@@ -330,12 +329,12 @@ export class UI extends EventEmitter<UIEvents> {
 
         this.replView.on('historyUp', () => {
             this.historyTree.incrementIndex()
-            updateReplInput()
+            updateReplInputWithHistory()
         })
 
         this.replView.on('historyDown', () => {
             this.historyTree.decrementIndex()
-            updateReplInput()
+            updateReplInputWithHistory()
         })
     }
 

--- a/src/vscode/__test__/UI.spec.ts
+++ b/src/vscode/__test__/UI.spec.ts
@@ -99,7 +99,6 @@ describe('UI tests', () => {
 
                 expect(historyMock.incrementIndex).toHaveBeenCalled()
                 expect(replMock.replClearInput).not.toHaveBeenCalled()
-                expect(replMock.replSetPackage).toHaveBeenCalledWith('foo')
                 expect(replMock.replSetInput).toHaveBeenCalledWith('bar')
             })
         })
@@ -125,7 +124,6 @@ describe('UI tests', () => {
 
                 expect(historyMock.decrementIndex).toHaveBeenCalled()
                 expect(replMock.replClearInput).not.toHaveBeenCalled()
-                expect(replMock.replSetPackage).toHaveBeenCalledWith('foo')
                 expect(replMock.replSetInput).toHaveBeenCalledWith('bar')
             })
         })


### PR DESCRIPTION
In the REPL, when I go up/down it sets both the package and the command. It's not ideal since most of the time I need to re-launch a command in another package etc. I would expect to only go back with commands sent and not with packages.

SLY works in the same way. I would try to separate packages and commands. If the user needs to actually use the history, it can be accessed via the history screen. In case we can add some shortcuts to navigate back with-package. But by default I would keep only commands.