### PR TITLE
Adding trace to right click menu, fixing stuck tooltip.

### DIFF
--- a/package.json
+++ b/package.json
@@ -296,19 +296,29 @@
                     "group": "x_commands@1"
                 },
                 {
-                    "command": "alive.sendToRepl",
+                    "command": "alive.traceFunction",
                     "when": "editorLangId == commonlisp",
                     "group": "x_commands@2"
                 },
                 {
-                    "command": "alive.loadFile",
+                    "command": "alive.untraceFunction",
                     "when": "editorLangId == commonlisp",
                     "group": "x_commands@3"
                 },
                 {
-                    "command": "alive.compileFile",
+                    "command": "alive.sendToRepl",
                     "when": "editorLangId == commonlisp",
                     "group": "x_commands@4"
+                },
+                {
+                    "command": "alive.loadFile",
+                    "when": "editorLangId == commonlisp",
+                    "group": "x_commands@5"
+                },
+                {
+                    "command": "alive.compileFile",
+                    "when": "editorLangId == commonlisp",
+                    "group": "x_commands@6"
                 }
             ],
             "view/title": [
@@ -400,6 +410,14 @@
                 },
                 {
                     "command": "alive.sendToRepl",
+                    "when": "editorLangId == commonlisp"
+                },
+                {
+                    "command": "alive.traceFunction",
+                    "when": "editorLangId == commonlisp"
+                },
+                {
+                    "command": "alive.untraceFunction",
                     "when": "editorLangId == commonlisp"
                 },
                 {

--- a/src/vscode/commands/Repl.ts
+++ b/src/vscode/commands/Repl.ts
@@ -49,11 +49,6 @@ export async function inlineEval(
         state.hoverText = `=> ${strToMarkdown(evalOutput)}`
         await vscode.window.showTextDocument(editor.document, editor.viewColumn)
         vscode.commands.executeCommand('editor.action.showHover')
-
-        // Clear the hover text after a 100 msec delay (to restore help tooltips afterwards)
-        setTimeout(() => {
-            state.hoverText = ''
-        }, 100)
     })
 }
 
@@ -90,11 +85,6 @@ export async function inlineEvalSurrounding(
         state.hoverText = `=> ${strToMarkdown(evalOutput)}`
         await vscode.window.showTextDocument(editor.document, editor.viewColumn)
         vscode.commands.executeCommand('editor.action.showHover')
-
-        // Clear the hover text after a 100 msec delay (to restore help tooltips afterwards)
-        setTimeout(() => {
-            state.hoverText = ''
-        }, 100)
     })
 }
 

--- a/src/vscode/commands/Repl.ts
+++ b/src/vscode/commands/Repl.ts
@@ -49,6 +49,11 @@ export async function inlineEval(
         state.hoverText = `=> ${strToMarkdown(evalOutput)}`
         await vscode.window.showTextDocument(editor.document, editor.viewColumn)
         vscode.commands.executeCommand('editor.action.showHover')
+
+        // Clear the hover text after a 100 msec delay (to restore help tooltips afterwards)
+        setTimeout(() => {
+            state.hoverText = ''
+        }, 100)
     })
 }
 
@@ -85,6 +90,11 @@ export async function inlineEvalSurrounding(
         state.hoverText = `=> ${strToMarkdown(evalOutput)}`
         await vscode.window.showTextDocument(editor.document, editor.viewColumn)
         vscode.commands.executeCommand('editor.action.showHover')
+
+        // Clear the hover text after a 100 msec delay (to restore help tooltips afterwards)
+        setTimeout(() => {
+            state.hoverText = ''
+        }, 100)
     })
 }
 


### PR DESCRIPTION
In this pull request I would like to add code that provides trace functionality in right click menu. In addition, with two minor additions I have fixed stuck tooltip, which occurs if one uses, for example, "Alive: Inline Eval". Then, at least for me, the tooltip does not show help for other functions anymore, but repeats the "=> function name" tooltip originally generated by "Alive: Inline Eval".