### PR TITLE
Allow null thread ids

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,9 +28,9 @@
             "args": [
                 "jest",
                 "--coverage",
-                "src/__test__/extension.spec.ts",
-                "-t",
-                "untraceFunctionNode"
+                "src/vscode/views/__test__/ThreadsTree.spec.ts"
+                // "-t",
+                // "untraceFunctionNode"
             ],
             "problemMatcher": ["$tsc"]
         },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "alive",
     "displayName": "Alive",
     "description": "Average Lisp VSCode Environment",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "publisher": "rheller",
     "license": "Unlicense",
     "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -169,7 +169,7 @@ export const activate = async (ctx: Pick<vscode.ExtensionContext, 'subscriptions
             if (!isLeafNode(node) || typeof node.label !== 'string' || node.label === '') {
                 return
             }
-            
+
             lsp.removeExport(node.pkg, node.label)
         }),
 
@@ -188,7 +188,7 @@ export const activate = async (ctx: Pick<vscode.ExtensionContext, 'subscriptions
         }),
 
         vscode.commands.registerCommand('alive.killThread', (node) => {
-            if (!isThreadNode(node) || typeof node.label !== 'string' || node.label === '') {
+            if (!isThreadNode(node)) {
                 return
             }
 

--- a/src/vscode/Guards.ts
+++ b/src/vscode/Guards.ts
@@ -53,7 +53,7 @@ export function isHistoryItem(data: unknown): data is HistoryItem {
 }
 
 export function isThread(data: unknown): data is Thread {
-    return isObject(data) && isString(data.id) && isString(data.name)
+    return isObject(data) && (isString(data.id) || data.id === null) && (isString(data.name) || data.name === null)
 }
 
 export function isPackage(data: unknown): data is Package {

--- a/src/vscode/Types.ts
+++ b/src/vscode/Types.ts
@@ -69,8 +69,8 @@ export interface TracedPackage {
 }
 
 export interface Thread {
-    id: string
-    name: string
+    id: string | null
+    name: string | null
 }
 
 export interface HistoryItem {

--- a/src/vscode/views/ThreadsTree.ts
+++ b/src/vscode/views/ThreadsTree.ts
@@ -5,7 +5,7 @@ export class ThreadNode extends vscode.TreeItem {
     public thread: Thread
 
     constructor(thread: Thread) {
-        super(thread.name)
+        super(thread.name ?? '')
 
         this.thread = thread
     }

--- a/src/vscode/views/__test__/ThreadsTree.spec.ts
+++ b/src/vscode/views/__test__/ThreadsTree.spec.ts
@@ -4,7 +4,10 @@ describe('ThreadsTree tests', () => {
     it('update', () => {
         const provider = new ThreadsTreeProvider([])
 
-        provider.update([{ id: 'foo', name: 'foo' }])
+        provider.update([
+            { id: 'foo', name: 'foo' },
+            { id: null, name: null },
+        ])
 
         const kids = provider.getChildren()
         expect(Array.isArray(kids)).toBe(true)
@@ -14,6 +17,8 @@ describe('ThreadsTree tests', () => {
 
         expect(isThreadNode(kids[0])).toBe(true)
         expect(kids[0].label).toBe('foo')
+        expect(isThreadNode(kids[1])).toBe(true)
+        expect(kids[1].label).toBe('')
     })
 
     it('getTreeItem', () => {


### PR DESCRIPTION
If a thread isn't given a name, the name and id are returned as null.